### PR TITLE
TestDataBuilders and new testMethods

### DIFF
--- a/fflib-sample-code/src/classes/InvoicingServiceTest.cls
+++ b/fflib-sample-code/src/classes/InvoicingServiceTest.cls
@@ -27,39 +27,133 @@
 @IsTest
 private class InvoicingServiceTest 
 {
-	@IsTest
-	private static void testService()
-	{
-		// Create Test Data
-		fflib_ISObjectUnitOfWork uow = Application.UnitOfWork.newInstance();
-		Opportunity opp = new Opportunity();
-		opp.Name = 'Opportunity';
-		opp.StageName = 'Open';
-		opp.CloseDate = System.today();
-		uow.registerNew(opp);		
-		for(Integer i=0; i<5; i++)
-		{						
-			Product2 product = new Product2();
-			product.Name = opp.Name + ' : Product : ' + i;
-			uow.registerNew(product);		
-			PricebookEntry pbe = new PricebookEntry();
-			pbe.UnitPrice = 10;
-			pbe.IsActive = true;
-			pbe.UseStandardPrice = false;
-			pbe.Pricebook2Id = Test.getStandardPricebookId();
-			uow.registerNew(pbe, PricebookEntry.Product2Id, product);		
-			OpportunityLineItem oppLineItem = new OpportunityLineItem();
-			oppLineItem.Quantity = 1;
-			oppLineItem.TotalPrice = 10;
-			uow.registerRelationship(oppLineItem, OpportunityLineItem.PricebookEntryId, pbe);
-			uow.registerNew(oppLineItem, OpportunityLineItem.OpportunityId, opp);
-		}
-		uow.commitWork();
+    @IsTest
+    private static void testService()
+    {
+        // Create Test Data
+        fflib_ISObjectUnitOfWork uow = Application.UnitOfWork.newInstance();
+        Opportunity opp = new Opportunity();
+        opp.Name = 'Opportunity';
+        opp.StageName = 'Open';
+        opp.CloseDate = System.today();
+        uow.registerNew(opp);       
+        for(Integer i=0; i<5; i++)
+        {                       
+            Product2 product = new Product2();
+            product.Name = opp.Name + ' : Product : ' + i;
+            uow.registerNew(product);       
+            PricebookEntry pbe = new PricebookEntry();
+            pbe.UnitPrice = 10;
+            pbe.IsActive = true;
+            pbe.UseStandardPrice = false;
+            pbe.Pricebook2Id = Test.getStandardPricebookId();
+            uow.registerNew(pbe, PricebookEntry.Product2Id, product);       
+            OpportunityLineItem oppLineItem = new OpportunityLineItem();
+            oppLineItem.Quantity = 1;
+            oppLineItem.TotalPrice = 10;
+            uow.registerRelationship(oppLineItem, OpportunityLineItem.PricebookEntryId, pbe);
+            uow.registerNew(oppLineItem, OpportunityLineItem.OpportunityId, opp);
+        }
+        uow.commitWork();
 
-		// Call Service
-		List<Id> invoiceIds = InvoicingService.generate(new List<Id> { opp.Id });
+        // Call Service
+        List<Id> invoiceIds = InvoicingService.generate(new List<Id> { opp.Id });
 
-		// Assert Invoices
-		System.assertEquals(1, invoiceIds.size());
-	}
+        // Assert Invoices
+        System.assertEquals(1, invoiceIds.size());
+    }
+
+
+    @isTest
+    private static void testService_UsingTestDataBuilders() {
+        
+        // Setup
+        Opportunity_t opp = new Opportunity_t()
+                                    .stage('Open')
+                                    .closes(System.today());
+        
+        for(Integer i=0; i<5; i++) {
+                                 opp.add(new OpportunityLineItem_t(new PriceBookEntry_t(new Product_t('Product ' + i))
+                                                                           .price(10)
+                                                                           .useStdPrice(false))
+                                                     .quantity(1)
+                                                     .totalPrice(10));
+        }
+            
+        opp.build(); 
+    
+
+        // Exercise
+        List<Id> invoiceIds = InvoicingService.generate(new List<Id> { opp.record.Id });
+
+        
+        // Verify
+        System.assertEquals(1, invoiceIds.size());
+    }
+    
+    
+    @isTest
+    private static void testService_VerifyAllBuiltObjects() {
+        
+        // Setup
+        Product_t prd = new Product_t();
+        
+        PriceBookEntry_t pbe = new PriceBookEntry_t(prd)
+                                            .price(10)
+                                            .useStdPrice(false);
+        
+        OpportunityLineItem_t oli = new OpportunityLineItem_t(pbe)
+                                            .quantity(1)
+                                            .totalPrice(10);
+        
+        Opportunity_t opp = new Opportunity_t()
+                                    .stage('Open')
+                                    .add(oli);
+        // Exercise
+        opp.build(); 
+
+        
+        // Verify
+        System.assertNotEquals(null, prd.record.Id);
+        System.assertNotEquals(null, pbe.record.Id);
+        System.assertNotEquals(null, oli.record.Id);
+        System.assertNotEquals(null, opp.record.Id);
+        
+    }
+    
+    
+    @isTest
+    private static void testService_GetSObjectFromBuilder() {
+        
+        // Setup
+        Opportunity_t opp = new Opportunity_t()
+                                    .stage('Closed')
+                                    .add(new OpportunityLineItem_t()
+                                                     .quantity(1)
+                                                     .totalPrice(10)); 
+        // Exercise
+        opp.build(); 
+
+        
+        // Verify
+        System.assertNotEquals(null, opp.record.Id);    // ! Access a Builders SObject record
+    }
+    
+    
+    @isTest
+    private static void testService_GetSObjectFromBuildMethod() {
+        
+        // Setup
+        Opportunity_t opp = new Opportunity_t()
+                                    .stage('Open')
+                                    .add(new OpportunityLineItem_t()
+                                                     .quantity(1)
+                                                     .totalPrice(10)); 
+        // Exercise
+        Opportunity oppRecord = (Opportunity) opp.build(); 
+
+        
+        // Verify
+        System.assertNotEquals(null, oppRecord.Id);     
+    }
 }

--- a/fflib-sample-code/src/classes/OpportunityLineItem_t.cls
+++ b/fflib-sample-code/src/classes/OpportunityLineItem_t.cls
@@ -1,0 +1,26 @@
+@isTest
+public with sharing class OpportunityLineItem_t extends fflib_DomainObjectBuilder {
+    
+    private OpportunityLineItem oli;
+    
+    // CONSTRUCTORS
+    
+    public OpportunityLineItem_t() {
+        this(new PriceBookEntry_t());
+    }
+    
+    public OpportunityLineItem_t(PriceBookEntry_t pbe) {
+        super(OpportunityLineItem.SObjectType, OpportunityLineItem.PriceBookEntryId, pbe);
+        oli = (OpportunityLineItem) record;
+    }
+    
+    // BUILDER METHODS
+
+    public OpportunityLineItem_t totalPrice(Decimal value) {
+       	return (OpportunityLineItem_t) set(OpportunityLineItem.TotalPrice, value);
+    }
+
+    public OpportunityLineItem_t quantity(Integer value) {
+       	return (OpportunityLineItem_t) set(OpportunityLineItem.Quantity, value);
+    }
+}

--- a/fflib-sample-code/src/classes/OpportunityLineItem_t.cls-meta.xml
+++ b/fflib-sample-code/src/classes/OpportunityLineItem_t.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>31.0</apiVersion>
+    <apiVersion>34.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/fflib-sample-code/src/classes/Opportunity_t.cls
+++ b/fflib-sample-code/src/classes/Opportunity_t.cls
@@ -1,0 +1,33 @@
+@isTest
+public class Opportunity_t extends fflib_DomainObjectBuilder {
+    
+    private Opportunity opt; 
+    
+    // CONSTRUCTORS
+    
+    public Opportunity_t(String name) {
+        super(Opportunity.SObjectType);
+        
+        opt = (Opportunity) record;
+        opt.Name = name;
+        closes(System.today());
+    }
+    
+    public Opportunity_t() {
+        this('Opportunity');
+    }
+    
+    // BUILDER METHODS
+
+    public Opportunity_t add(OpportunityLineItem_t oli) {
+        return (Opportunity_t) oli.setParent(OpportunityLineItem.OpportunityId, this);
+    }
+
+    public Opportunity_t stage(String value) {
+        return (Opportunity_t) set(Opportunity.StageName, value);
+    }
+
+    public Opportunity_t closes(Date value) {
+        return (Opportunity_t) set(Opportunity.CloseDate, value);
+    }
+}

--- a/fflib-sample-code/src/classes/Opportunity_t.cls-meta.xml
+++ b/fflib-sample-code/src/classes/Opportunity_t.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>31.0</apiVersion>
+    <apiVersion>34.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/fflib-sample-code/src/classes/PricebookEntry_t.cls
+++ b/fflib-sample-code/src/classes/PricebookEntry_t.cls
@@ -1,0 +1,30 @@
+@isTest
+public with sharing class PricebookEntry_t extends fflib_DomainObjectBuilder {
+    
+    private PricebookEntry pbe;
+    
+    // CONSTRUCTORS
+    
+    public PricebookEntry_t() {
+        this(new Product_t());
+    }
+    
+    public PricebookEntry_t(Product_t prd) {
+        super(PricebookEntry.SObjectType, PricebookEntry.Product2Id , prd);
+        
+        pbe = (PricebookEntry) record;
+        pbe.Pricebook2Id = Test.getStandardPricebookId();
+        pbe.IsActive = true;
+        price(0);
+    }
+    
+    // BUILDER METHODS
+    
+    public PricebookEntry_t price(Decimal value) {
+        return (PricebookEntry_t) set(PricebookEntry.UnitPrice, value);
+    }
+    
+    public PricebookEntry_t useStdPrice(Boolean value) {
+        return (PricebookEntry_t) set(PricebookEntry.UseStandardPrice, value);
+    }
+}

--- a/fflib-sample-code/src/classes/PricebookEntry_t.cls-meta.xml
+++ b/fflib-sample-code/src/classes/PricebookEntry_t.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>31.0</apiVersion>
+    <apiVersion>34.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/fflib-sample-code/src/classes/Product_t.cls
+++ b/fflib-sample-code/src/classes/Product_t.cls
@@ -1,0 +1,24 @@
+@isTest
+public with sharing class Product_t extends fflib_DomainObjectBuilder {
+    
+    private Product2 prd;
+    
+    // CONSTRUCTORS
+    
+    public Product_t(String name) {
+        super(Product2.SObjectType);
+        
+        prd = (Product2) record;
+        prd.Name = name;
+    }
+    
+    public Product_t() {
+        this('Product');
+    }
+    
+    // BUILDER METHODS
+
+    public Product_t add(PricebookEntry_t pbe) {
+        return (Product_t) pbe.setParent(PricebookEntry.Product2Id, this);
+    }
+}

--- a/fflib-sample-code/src/classes/Product_t.cls-meta.xml
+++ b/fflib-sample-code/src/classes/Product_t.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>31.0</apiVersion>
+    <apiVersion>34.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
_As promised in my [Stackexchange question](http://salesforce.stackexchange.com/questions/77387/how-to-best-use-the-test-data-builder-pattern-in-a-database-context) I hereby (ask) to contribute a new Pattern called TestDataBuilder. I think it could be of high use to many library users that have complex data structures that they need to run Apex Integration tests on. I have submitted a pull request to [fflib-apex-common](https://github.com/financialforcedev/fflib-apex-common) includung a TestDataBuilder base class and another pull request to [fflib-apex-common-samplecode](https://github.com/financialforcedev/fflib-apex-common-samplecode) with sample code showing how to use it._

There is awesome support in the library for Apex unit test. They should be fast and isolated. With [ApexMocks](https://github.com/financialforcedev/fflib-apex-mocks) [both is achieved](http://andyinthecloud.com/2015/03/22/unit-testing-with-apex-enterprise-patterns-and-apexmocks-part-1/). But complex code also needs integration tests where code is execute on more complex test data. In the world of Enterprise software outside of Salesforce.com there are experts that have created patterns for flexible and readable (fluent, concise) test data generation.

Among them the most notable is [Nat Pryce](http://www.natpryce.com/) who wrote a [great book](http://www.amazon.com/Growing-Object-Oriented-Software-Guided-Tests/dp/0321503627) about testing and somewhat invented the [TestDataBuilder pattern](http://www.natpryce.com/articles/000714.html). 

Up2Go as a Salesforce.com ISV has products with huge amount of Integration test where each of them needs to build up huge "trees" of related records. Over the year we suffered from our complex and mostly redundant TestHelpers classes where each created the same object slightly different. Whenever we changed the datamodel we had to sync all the Helpers or otherwise tests would magically fail.
- By incorporating **a single short** Builder class for each test-relevant Domain SObject we could centralize all the creation knowledge and eliminating redundancy. 
- By internally leveraging the 'fflib_SObjectUnitOfWork' for the DML all **test run dramatically faster**.
- The [Fluent API](https://en.wikipedia.org/wiki/Fluent_interface) style of the Builder pattern combined with having all the database wiring encapsulated in the Unit of work made each test much more understandable.
